### PR TITLE
fix: type definitions not published in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "types": "./index.d.ts",
   "files": [
     "index.js",
-    "index.d.js",
+    "index.d.ts",
     "dist/*"
   ],
   "scripts": {


### PR DESCRIPTION
`package.files[]` used to include a wrong path to the type definitions file (`index.d.js` instead of `index.d.ts`), and as such, they didn't get published into the npm package, leaving consumers of this package without proper type definitions.

![Screenshot 2021-06-11 210908](https://user-images.githubusercontent.com/1512067/121737561-519f6480-caf9-11eb-9235-ba11662dfd29.png)

This PR fixes that by changing the path in `package.files[]` from `index.d.js` to `index.d.ts`

## How to validate

Run `npm publish --dry-run` on `master`:

```
$ npm publish --dry-run
npm notice 
npm notice 📦  @next-auth/react-query@0.0.8
npm notice === Tarball Contents === 
npm notice 3.7kB  README.md     
npm notice 55.1kB dist/index.js 
npm notice 55.0kB dist/index.mjs
npm notice 730B   index.js      
npm notice 1.5kB  package.json  
npm notice === Tarball Details === 
npm notice name:          @next-auth/react-query                  
npm notice version:       0.0.8                                   
npm notice filename:      @next-auth/react-query-0.0.8.tgz        
npm notice package size:  38.3 kB                                 
npm notice unpacked size: 116.1 kB                                
npm notice shasum:        ebe3358bcc79a8c479861fc16ef51d9b425e3d16
npm notice integrity:     sha512-DWbWDDNRCa+eU[...]19OdZO1F0LA6w==
npm notice total files:   5                                       
npm notice 
+ @next-auth/react-query@0.0.8
```

See how it doesn't contain `index.d.ts`.

Now, run the same `npm publish --dry-run` on this branch:

```
$ npm publish --dry-run
npm notice 
npm notice 📦  @next-auth/react-query@0.0.8
npm notice === Tarball Contents === 
npm notice 3.7kB  README.md     
npm notice 55.1kB dist/index.js 
npm notice 55.0kB dist/index.mjs
npm notice 912B   index.d.ts    
npm notice 730B   index.js      
npm notice 1.5kB  package.json  
npm notice === Tarball Details === 
npm notice name:          @next-auth/react-query                  
npm notice version:       0.0.8                                   
npm notice filename:      @next-auth/react-query-0.0.8.tgz        
npm notice package size:  38.7 kB                                 
npm notice unpacked size: 117.0 kB                                
npm notice shasum:        60503efa2afc5505a848477e2f138a3e54f1e619
npm notice integrity:     sha512-2WVGrFeX8g2lw[...]DOOhcZ2ODZDEg==
npm notice total files:   6                                       
npm notice 
+ @next-auth/react-query@0.0.8
```

It now contains `index.d.ts`.

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

~[ ] Documentation~
~[ ] Tests~
- [x] Ready to be merged
