### PR TITLE
Default queryConfig to empty object

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ export async function fetchSession() {
 export function useSession({
   required,
   redirectTo = "/api/auth/signin?error=SessionExpired",
-  queryConfig,
+  queryConfig = {},
 } = {}) {
   const router = useRouter()
   const query = useQuery(["session"], fetchSession, {


### PR DESCRIPTION
## Reasoning 💡

Tiny change! I'd like to see the queryConfig parameter defaulted to an empty object so that if it isn't specified, we don't see an error calling useSession.

## Checklist 🧢

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

I haven't run tests to check this yet. Documentation already talks about `{}` as the default.