### PR TITLE
docs: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ const [session, loading] = useSession({
   required: true,
   redirectTo: "/auth/sign-in?error=InvalidSession",
   queryConfig: {
-    staleTime: 60 * 60 * 3, // 3 hours
-    refetchInterval: 60 * 5 // 5 minutes 
+    staleTime: 60 * 1000 * 60 * 3, // 3 hours
+    refetchInterval: 60 * 1000 * 5 // 5 minutes 
   }
 })
 ...


### PR DESCRIPTION
## Reasoning 💡

In  the documentation of [API reference](https://github.com/nextauthjs/react-query#usesessionparams) the `staleTime` and `refetchInterval` comments are incorrect as react-query uses milliseconds. 